### PR TITLE
Corrected syntax

### DIFF
--- a/docs/Kafka.md
+++ b/docs/Kafka.md
@@ -1,6 +1,6 @@
 ### com.esri.rttest.send.Kafka
 
-$ java -cp rttest.jar com.esri.send.Kafka 
+$ java -cp rttest.jar com.esri.rttest.send.Kafka 
 
 Usage: Kafka (broker-list) (topic) (file) (rate) (numrecords)
 - Sends lines from file to the specified broker-list.  


### PR DESCRIPTION
Previous syntax excluded `rttest` in the class path.