### PR TITLE
Updated command line

### DIFF
--- a/docs/send/Kafka.md
+++ b/docs/send/Kafka.md
@@ -1,6 +1,6 @@
 ### com.esri.rttest.send.Kafka
 
-$ java -cp rttest.jar com.esri.send.Kafka 
+$ java -cp rttest.jar com.esri.rttest.send.Kafka 
 
 Usage: Kafka (broker-list) (topic) (file) (rate) (numrecords)
 - Sends lines from file to the specified broker-list.  


### PR DESCRIPTION
I believe this was changed at some point.  Currently takes com.esri.rttest.send.Kafka, was missing 'rttest'