### PR TITLE
Adding flexibility for sending, all 2xx codes considered successful

### DIFF
--- a/src/main/java/com/esri/rttest/send/HttpThread.java
+++ b/src/main/java/com/esri/rttest/send/HttpThread.java
@@ -139,7 +139,7 @@ public class HttpThread extends Thread {
 
                 HttpResponse resp = httpClient.execute(httpPost);
 
-                if (resp.getStatusLine().getStatusCode() != 200) {
+                if (resp.getStatusLine().getStatusCode() > 299 || resp.getStatusLine().getStatusCode() < 200) {
                     cntErr += 1;
                 }
 


### PR DESCRIPTION
@david618 , I adjusted HTTP sender locally to accept all 2xx codes as non-errors.  Let me know if your thoughts on this implementation and if you think this should be included in your main