### PR TITLE
Handling NoHTTPResponseException;  Occasionally we get this and now will not terminate

### DIFF
--- a/src/main/java/com/esri/rttest/send/HttpThread.java
+++ b/src/main/java/com/esri/rttest/send/HttpThread.java
@@ -26,6 +26,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import org.apache.http.NoHttpResponseException;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
@@ -151,11 +152,14 @@ public class HttpThread extends Thread {
 
             }
 
+        } catch (NoHttpResponseException e) {
+            LOG.debug("ERROR", e);
+            System.err.println(e.getClass() + ": " + e.getMessage());
+            //don't terminate
         } catch (Exception e) {
             LOG.debug("ERROR", e);
             System.err.println(e.getClass() + ": " + e.getMessage());
             terminate();
-
         }
     }
 }


### PR DESCRIPTION
@david618 , when running HTTP send for long periods against our devops cluster for soak testing, I would periodically get the following that would then kill the running application:
```
|            1150515 |                  5 |                  5 |
class org.apache.http.NoHttpResponseException: 52.156.89.132:443 failed to respond
|            1150520 |                  5 |                  5 |
Threads have all failed
```

I added a catch specifically for this where I don't call `terminate()`  Let me know your thoughts on the implementation and if you think it warrants inclusion.