### PR TITLE
Revert to sending POSTs via DNS.  Via IP causes SocketExceptions when sending directly to receiver proxy

### DIFF
--- a/src/main/java/com/esri/rttest/send/Http.java
+++ b/src/main/java/com/esri/rttest/send/Http.java
@@ -29,8 +29,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import com.esri.rttest.IPPort;
-import com.esri.rttest.IPPorts;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 /**
@@ -105,21 +103,14 @@ public class Http extends Send {
         this.filename = filename;
         this.reuseFile = reuseFile;
 
-        // Turn url into ip(s)
-        IPPorts ipp = new IPPorts(url);
-        ArrayList<IPPort> ipPorts = ipp.getIPPorts();
-
         // Create the HttpThread
         threads = new HttpThread[numThreads];
 
         try {
             for (int i = 0; i < threads.length; i++) {
 
-                // Rotating through ip's create threads requested
-                IPPort ipport = ipPorts.get(i % ipPorts.size());
-                String thdURL = ipp.getProtocol() + "://" + ipport.getIp() + ":" + ipport.getPort() + ipp.getPath();
-                System.out.println(thdURL);
-                threads[i] = new HttpThread(lbq, thdURL, contentType);
+                System.out.println(url);
+                threads[i] = new HttpThread(lbq, url, contentType);
 
                 threads[i].start();
             }

--- a/src/main/java/com/esri/rttest/send/Http.java
+++ b/src/main/java/com/esri/rttest/send/Http.java
@@ -124,12 +124,6 @@ public class Http extends Send {
 
     }
 
-    private static final String IPADDRESS_PATTERN
-            = "^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\."
-            + "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\."
-            + "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\."
-            + "([01]?\\d\\d?|2[0-4]\\d|25[0-5])$";
-
     LinkedBlockingQueue<String> lbq = new LinkedBlockingQueue<>();
 
 


### PR DESCRIPTION
@david618 , I went ahead and removed.  Thought I'd share for your consideration.  Feel free to reject if you want to create a different approach. Or if you wanted want me to change anything, this could be a fun task to collaborate for me learn a bit more.